### PR TITLE
Added hotkey support for opening file dialog on ImportCharacter screen

### DIFF
--- a/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/Screens/ImportCharacter.gd
+++ b/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/Screens/ImportCharacter.gd
@@ -31,6 +31,10 @@ func _ready() -> void:
 func _on_Button_pressed():
 	$FileDialog.popup()
 
+# Opens the file dialog popup when the custom hotkey (e.g., Ctrl + O) is pressed
+func _unhandled_input(event):
+	if Input.is_action_pressed("open_file_hotkey"):
+		$FileDialog.popup()
 
 #FUNCTION populate preset character format
 #Params: file we have opened and are reading

--- a/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/project.godot
+++ b/Phase2/Godot_GameCode/_MVP_Game_Demo/Active_Master/bcirpg_game_mvp_2024_0721A/project.godot
@@ -110,6 +110,14 @@ DiceRoller="*res://globalScripts/DiceRoller.gd"
 GlobalSaveInstance="*res://globalScripts/globalSaveInstance.gd"
 GameCurrent="*res://globalScripts/gameCurrent.gd"
 
+[input]
+
+open_file_hotkey={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":true,"command":true,"pressed":false,"scancode":0,"physical_scancode":79,"unicode":0,"echo":false,"script":null)
+ ]
+}
+
 [physics]
 
 common/enable_pause_aware_picking=true


### PR DESCRIPTION
This pull request adds support for a keyboard hotkey (open_file_hotkey) to open the character import file dialog. It improves accessibility for keyboard-only and BCI users.

Changes
Added open_file_hotkey in Input Map
Implemented _unhandled_input() in ImportCharacter.gd
Opens $FileDialog when the hotkey is pressed

Tested
Verified that pressing the hotkey triggers the file dialog without needing a mouse click
Tested in both default and custom themes